### PR TITLE
Update requirements.txt with aiohttp

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ argparse
 terminal_banner
 termcolor
 rich
+aiohttp


### PR DESCRIPTION
Commit https://github.com/pratraut/scrapyFi/commit/db148ac4dec5401236a3eef396a6b1c930267616 from 3 weeks ago introduced two new imports in `lib/helper.py`, asyncio and aiohttp.
https://github.com/pratraut/scrapyFi/blob/db148ac4dec5401236a3eef396a6b1c930267616/lib/helper.py#L6-L7

Adding `aiohttp` to requirements.txt as we ran into an error for not having the module installed.